### PR TITLE
Add TensorFlow to optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The package provides:
 
 ## Install
 
-Requires Python 3.8 or later. You can install `ewstools` with pip using the commands
+Requires Python between 3.8 and 3.11. You can install `ewstools` with pip using the commands
 
 ```bash
 pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -52,12 +52,16 @@ Package dependencies are
 'pandas>=0.23.0',
 'numpy>=1.14.0',
 'plotly>=2.3.0',
-'lmfit>=0.9.0', 
+'lmfit>=0.9.0',
 'arch>=4.4',
 'statsmodels>=0.9.0',
 'scipy>=1.0.1',
 ```
-and should be installed automatically. To use the deep learning functionality, you will need to install [TensorFlow](https://www.tensorflow.org/install) with version later than 2.10 and earlier than 2.16.
+and should be installed automatically. To use the deep learning functionality, you will need to install [TensorFlow](https://www.tensorflow.org/install) with the command
+```bash
+pip install ewstools[tf]
+```
+Note that TensorFlow has no wheels on Windows, therefore can only be installed on Linux and macOS.
 
 To install the latest *development* version, use the command
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "2.1.2"
 description = "A Python package for early warning signals (EWS) of bifurcations in time series data."
 authors = [{ name = "Thomas M Bury", email = "tombury182@gmail.com" }]
 readme = "README.md"
-requires-python = ">=3.8" # Adjust based on your supported Python version
+requires-python = ">=3.8,<3.12" # Adjust based on your supported Python version
 dependencies = [
     "pandas>=0.23.0",
     "numpy>=1.14.0,<1.25.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,11 @@ classifiers = [
 [project.urls]
 "Homepage" = "https://github.com/ThomasMBury/ewstools"
 
+[project.optional-dependencies]
+tf = [
+    "tensorflow>=2.10,<=2.16 ; sys_platform != 'win32'",
+]
+
 [tool.setuptools.packages]
 find = {}
 


### PR DESCRIPTION
I've added the Tensorflow optional dependencies to pyproject.toml, following version restrictions in the original README.

I've also edited the README to specify the installation process of the extra packages, according to [PEP 508](https://peps.python.org/pep-0508/#extras).

I hope this is good and you appreciateit!. It would make installation easier for users as it would handle dependencies automatically. Note that due to compatibilities with Numpy and TensorFlow, Python version had to be set below 3.12!