### PR TITLE
NumPy 2.x compatibility + dependency floor updates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
             pytest --doctest-modules --cov=ewstools --cov-report=xml tests/      
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ./coverage.xml
           verbose: true # optional (default = false)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,13 @@ authors = [{ name = "Thomas M Bury", email = "tombury182@gmail.com" }]
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
-    "pandas>=0.23.0",
+    "pandas>=1.3.0",
     "numpy>=1.26.0,<2.0",  # 1.26 is oldest with 3.12 wheels; <2.0 avoids breaking changes
-    "plotly>=2.3.0",
-    "lmfit>=0.9.0",
+    "plotly>=4.0.0",
+    "lmfit>=1.0.0",
     "arch>=6.2",  # 6.2 is oldest with compiled 3.12 wheels
-    "statsmodels>=0.9.0",
-    "scipy>=1.0.1",
+    "statsmodels>=0.13.0",
+    "scipy>=1.7.0",
     "deprecation>=2.0",
     "entropyhub>=2.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
     "pandas>=1.3.0",
-    "numpy>=1.26.0,<2.0",  # 1.26 is oldest with 3.12 wheels; <2.0 avoids breaking changes
+    "numpy>=1.26.0",  # tested compatible with numpy 2.x + EntropyHub
     "plotly>=4.0.0",
     "lmfit>=1.0.0",
     "arch>=6.2",  # 6.2 is oldest with compiled 3.12 wheels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ tf = [
 
 [tool.pytest.ini_options]
 markers = ["tensorflow: tests requiring TensorFlow (deselect with '-m \"not tensorflow\"')"]
+addopts = "--strict-markers"
 
 [tool.setuptools.packages]
 find = {}


### PR DESCRIPTION
## Summary

- Remove `numpy<2.0` constraint — tested compatible with NumPy 2.x and current EntropyHub
- Bump dependency floors to realistic minimums (pandas 1.3+, plotly 4.0+, lmfit 1.0+, statsmodels 0.13+, scipy 1.7+)
- Upgrade codecov GitHub Action v3 → v4 (v3 deprecated)
- Add `--strict-markers` to pytest config (catches typos in marker names)

## Motivation

The `numpy<2.0` pin was blocking users on Python 3.12+ from installing with modern environments where NumPy 2.x is the default. EntropyHub now supports NumPy 2.x, removing the original reason for the pin.

The dependency floor bumps remove versions that are 5-8 years old and no longer tested against. No functionality changes — purely compatibility maintenance.

## Test plan

- [x] All existing tests pass locally with NumPy 2.x installed
- [x] CI should confirm on matrix (Python 3.9-3.12)