### PR TITLE
Release hygiene for 2.1.3: date the notes, document the entropy fix, cite upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to `ewstools` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.3] — unreleased
+## [2.1.3] — 2026-07-28
 
 Maintenance release. **No API changes and no behavioural changes** — existing code and
 notebooks run unmodified.
@@ -20,6 +20,18 @@ notebooks run unmodified.
   The code fix landed on `main` in March 2026 but had not been published to PyPI, so every
   released install still carried the break. This release ships it.
   Reported in [#474](https://github.com/ThomasMBury/ewstools/issues/474).
+
+- **`compute_entropy(method='kolmogorov')` now works on NumPy 2.** EntropyHub 2.0 — its
+  latest release — still uses `np.NaN`, which NumPy removed in 2.0, so `EH.K2En()` and
+  `EH.CoSiEn()` raised `AttributeError`. `ewstools`' own source was already clean; the
+  alias is restored immediately before the EntropyHub import, and `np.NaN` was only ever
+  a spelling of `np.nan`, so nothing changes numerically. This matters *because* of the
+  NumPy change below: lifting the `numpy<2` ceiling is what puts users on the stack where
+  the break appears, and it was a partial break — `method='sample'` worked while
+  `method='kolmogorov'` failed — which stays hidden until someone reaches for that method.
+  Verified on NumPy 2.4.6 / pandas 3.0.5 / SciPy 1.17.1: fails without the shim, passes
+  with it. Covered by a regression test. The shim can be dropped once EntropyHub ships a
+  NumPy 2 compatible release ([EntropyHub#21](https://github.com/MattWillFlood/EntropyHub/issues/21)).
 
 ### Changed
 
@@ -49,3 +61,7 @@ The single skip is the TensorFlow deep-learning test, which guards itself with
 
 Against released 2.1.2 in the same container, all four spectral entry points fail; on this
 branch all four pass.
+
+These container runs predate the `compute_entropy` fix above, which adds a regression test —
+hence 30 here and 31 in the suite as shipped. That fix was verified separately, on
+NumPy 2.4.6 / pandas 3.0.5 / SciPy 1.17.1.

--- a/ewstools/core.py
+++ b/ewstools/core.py
@@ -58,7 +58,8 @@ from plotly.subplots import make_subplots
 # 2.0 — so EH.K2En() and EH.CoSiEn() raise AttributeError on a modern stack even
 # though ewstools itself is clean. Restore the alias before importing EntropyHub;
 # `np.NaN` was only ever a spelling of `np.nan`, so this is not a behaviour change.
-# Remove once EntropyHub ships a NumPy 2 compatible release (reported upstream).
+# Remove once EntropyHub ships a NumPy 2 compatible release; tracked upstream at
+# https://github.com/MattWillFlood/EntropyHub/issues/21 (open, latest release is still 2.0).
 if not hasattr(np, "NaN"):  # pragma: no cover - depends on installed NumPy
     np.NaN = np.nan
 


### PR DESCRIPTION
The code for 2.1.3 is done and `main` is green. This is the paperwork, plus the one step that only you can take.

## What this changes

**1. The changelog says `## [2.1.3] — unreleased`.** Tag it as-is and the shipped release notes announce that the release hasn't happened. Now dated.

**2. The `compute_entropy` fix (88e7f38) is missing from the notes.** It landed after they were written, and it's the entry a 2.1.3 user most needs, because *this* is the release that lifts the `numpy<2` ceiling — which is what puts people on the stack where EntropyHub's `np.NaN` break appears. It was also a partial break (`method='sample'` fine, `method='kolmogorov'` raising `AttributeError`), and partial breaks stay hidden until someone reaches for the failing path. Now documented under **Fixed**.

**3. `core.py` claimed the EntropyHub bug was "(reported upstream)" with no reference.** I checked before trusting it: we filed nothing there. A report *does* exist — [EntropyHub#21](https://github.com/MattWillFlood/EntropyHub/issues/21), opened 2026-07-15 by a third party, still open, and EntropyHub's latest release is still 2.0 — so the claim was true in substance and misleading in attribution. Now cited by number, so whoever eventually removes the shim has a tracking link rather than a rumour.

The `30` vs `31` test count in the verification table is left **as measured**. Those container runs predate the entropy regression test; re-labelling numbers we didn't re-run would be worse than explaining them, so a note explains them.

No functional change. Suite green: 31 passed, 1 skipped.

## The remaining step, which is yours

`publish-pypi` authenticates by OIDC trusted publishing, so it needs a publisher registered on the PyPI project. That page is **Owner-only** — I'm a maintainer, so I can't:

    https://pypi.org/manage/project/ewstools/settings/publishing/
      Owner            : ThomasMBury
      Repository name  : ewstools
      Workflow filename: release.yml
      Environment name : pypi

Worth doing **Actions ▸ Release ▸ Run workflow ▸ target `testpypi`** first if you set up the TestPyPI side too — it exercises the whole path without touching real PyPI.

Once the publisher is registered, tagging does the rest:

    git tag v2.1.3 && git push origin v2.1.3

The build job fails loudly if the tag and `pyproject.toml` disagree, *before* anything is uploaded. If the publisher isn't registered the OIDC exchange just fails — nothing uploads, and the tag can be deleted and re-pushed. The only irreversible step is a successful publish: PyPI version numbers can be yanked but never reused.

Happy to push the tag myself once you've done the PyPI side — say the word. It's your package; I didn't want to cut a release under your name without you saying so.

One promise outstanding either way: I told Olivier on #474 that I'd comment there once 2.1.3 is on PyPI so he knows to drop the workaround. I'll do that when it lands.