### PR TITLE
Derive the docs version instead of hardcoding it

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,8 +24,44 @@ project = "ewstools"
 copyright = "2022, Thomas M Bury"
 author = "Thomas M Bury"
 
-# Semantic version number
-version = "2.1.1"
+# Semantic version number.
+#
+# Derived, never hardcoded. This line had to be bumped by hand, so it drifted:
+# it still read 2.1.1 while the package was on 2.1.3.
+#
+# Resolution order: installed package metadata first, because that is how the
+# docs are actually built (.readthedocs.yaml installs the package, and so does
+# CI); then pyproject.toml, for a build tree where the package is not installed;
+# then a literal fallback.
+#
+# This must not raise under any circumstances: .readthedocs.yaml sets
+# `sphinx.fail_on_warning`, so an exception here takes the whole build down.
+def _resolve_version():
+    try:
+        from importlib.metadata import version as _installed_version
+
+        return _installed_version("ewstools")
+    except Exception:
+        pass
+    try:
+        import tomllib  # standard library on Python 3.11+ only
+
+        _pyproject = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "..", "..", "pyproject.toml"
+        )
+        with open(_pyproject, "rb") as _f:
+            return tomllib.load(_f)["project"]["version"]
+    except Exception:
+        pass
+    return "unknown"
+
+
+version = _resolve_version()
+
+# The sphinx_rtd_theme displays `release`, not `version`. Leaving `release`
+# unset is why the stale value above went unnoticed across two releases: it was
+# wrong, but it was never rendered anywhere a reader would see it.
+release = version
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
Small follow-on to your docs pass this morning — different thing, so I split it out.

`docs/source/conf.py` had `version = "2.1.1"` hardcoded. It has to be bumped by hand, so it drifted: it was already stale for 2.1.2 and stayed stale through 2.1.3.

The reason nobody noticed is worth a sentence, because it's the actual bug. Only `version` was set, and `sphinx_rtd_theme` renders `release`. So the wrong number existed but was never displayed anywhere a reader could see it — the page title read "ewstools documentation" with no version at all.

This resolves the version instead:

1. installed package metadata — which is how the docs are really built, since `.readthedocs.yaml` pip-installs the package and so does CI
2. `pyproject.toml`, for a tree where the package isn't installed
3. a literal fallback

and sets `release` as well as `version`, so it's actually rendered.

The resolver cannot raise. `fail_on_warning: true` is set, so an exception in `conf.py` would take the whole build down; every branch is wrapped and the last resort is the string `unknown`.

### Verification

Built exactly as RTD does (`docs/requirements.txt` + the package, `sphinx-build -W`). Build clean, and the rendered title is now:

```
$ grep -o '[^<>]*2\.1\.3[^<>]*' index.html
ewstools &mdash; ewstools 2.1.3 documentation
```

Also checked the two fallbacks in isolation, since the first branch normally hides them: with the package absent it returns `2.1.3` from `pyproject.toml`, and on an interpreter without `tomllib` (3.10 and earlier) it returns `unknown` rather than raising.

### One thing I did not change

`.zenodo.json` also pins `"version": "v2.1.1"` and a hardcoded `"publication_date": "2023-02-10"`. I was going to clean those up in the same PR, but I couldn't confirm from Zenodo's own documentation what happens when those fields are omitted — their docs say `publication_date` defaults to the current date, but say nothing about `version` being taken from the release tag. Rather than guess in a metadata file, I've left it alone and mentioned it separately. It looks inert anyway: the Zenodo API only has the one 2023 record, so the GitHub integration doesn't appear to be firing.

No rush on this one.